### PR TITLE
[Feature] Allow Tesla.Adapter to be set via config

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 elixir 1.9.4
+erlang 23.1.2

--- a/lib/elastic/http.ex
+++ b/lib/elastic/http.ex
@@ -126,7 +126,12 @@ defmodule Elastic.HTTP do
           basic_auth_middleware(options)
         ]
 
-    client = Tesla.client(middlewares, Tesla.Adapter.Hackney)
+    client =
+      Tesla.client(
+        middlewares,
+        Application.get_env(:elastic, :tesla_adapter, Tesla.Adapter.Hackney)
+      )
+
     Tesla.request(client, options) |> process_response
   end
 


### PR DESCRIPTION
`Tesla.Adapter.Hackney` was hard-coded, and not overridable. This change allows setting a `:tesla_adapter` config value to override the adapter.