### PR TITLE
[Feat] Allow configuring middleware from config

### DIFF
--- a/lib/elastic/http.ex
+++ b/lib/elastic/http.ex
@@ -109,6 +109,7 @@ defmodule Elastic.HTTP do
   defp request(method, url, options) do
     body = Keyword.get(options, :body, []) |> encode_body
     timeout = Application.get_env(:elastic, :timeout, 30_000)
+    config_middlewares = Application.get_env(:elastic, :middlewares, [])
 
     options =
       options
@@ -121,10 +122,12 @@ defmodule Elastic.HTTP do
       |> add_aws_header(method, url, body)
 
     middlewares =
-      Keyword.get(options, :middlewares, []) ++
-        [
-          basic_auth_middleware(options)
-        ]
+      [
+        Keyword.get(options, :middlewares, []),
+        basic_auth_middleware(options),
+        config_middlewares
+      ]
+      |> List.flatten()
 
     client =
       Tesla.client(

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 defmodule Elastic.Mixfile do
   use Mix.Project
-  @version "3.5.4"
+  @version "3.6.2"
 
   def project do
     [
@@ -57,7 +57,7 @@ defmodule Elastic.Mixfile do
       name: :elastic,
       description: "You Know, for (Elastic) Search",
       files: ["lib", "README*", "mix.exs"],
-      maintainers: ["Ryan Bigg", "Oleks Shturmov"],
+      maintainers: ["Ryan Bigg", "Flexibility.ai"],
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/flexibility-org/elastic"}
     ]

--- a/test/elastic/http_test.exs
+++ b/test/elastic/http_test.exs
@@ -1,2 +1,29 @@
 defmodule Elastic.HTTPTest do
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
+
+  describe "Set middlewares from config" do
+    setup do
+      Logger.configure(level: :debug)
+      Application.delete_env(:elastic, :middlewares)
+
+      :ok
+    end
+
+    test "with logger" do
+      Application.put_env(
+        :elastic,
+        :middlewares,
+        [{Tesla.Middleware.Logger, debug: true, log_level: :debug}]
+      )
+
+      log =
+        capture_log(fn ->
+          Elastic.HTTP.get(Elastic.base_url() <> "/answer/_search")
+        end)
+
+      assert log =~ "[debug] GET http://localhost:9200/answer/_search"
+      assert log =~ "authorization: Basic"
+    end
+  end
 end


### PR DESCRIPTION
## Changes

Allows middleware to be configured at a global level, useful for logging, compression, etc.