### PR TITLE
[Fix] Replace module attributes with function calls

### DIFF
--- a/lib/elastic/kibana/role.ex
+++ b/lib/elastic/kibana/role.ex
@@ -15,7 +15,7 @@ defmodule Elastic.Kibana.Role do
   alias Elastic.ResponseHandler
   alias Elastic.User.Name
 
-  @base_url Elastic.base_kibana_url() <> "/api/security/role/"
+  defp security_root, do: Elastic.base_kibana_url() <> "/api/security/role/"
 
   @spec upsert(
           name :: binary(),
@@ -23,7 +23,7 @@ defmodule Elastic.Kibana.Role do
         ) :: :ok | ResponseHandler.unknown_response_value()
   def upsert(name, kibana_privileges \\ []) do
     response =
-      HTTP.put(@base_url <> Name.url_encode(name),
+      HTTP.put(security_root() <> Name.url_encode(name),
         body: %{kibana: kibana_privileges},
         middlewares: [HTTP.kibana_middleware()]
       )
@@ -40,7 +40,7 @@ defmodule Elastic.Kibana.Role do
   @spec delete(name :: binary()) :: ResponseHandler.find_result()
   def delete(name) do
     response =
-      HTTP.delete(@base_url <> Name.url_encode(name),
+      HTTP.delete(security_root() <> Name.url_encode(name),
         middlewares: [HTTP.kibana_middleware()]
       )
 
@@ -60,8 +60,8 @@ defmodule Elastic.Kibana.Role do
   def get(name \\ nil) do
     url =
       case name do
-        nil -> String.slice(@base_url, 0..-2)
-        _ -> @base_url <> Name.url_encode(name)
+        nil -> String.slice(security_root(), 0..-2)
+        _ -> security_root() <> Name.url_encode(name)
       end
 
     response = HTTP.get(url)

--- a/lib/elastic/role.ex
+++ b/lib/elastic/role.ex
@@ -14,7 +14,7 @@ defmodule Elastic.Role do
   alias Elastic.ResponseHandler
   alias Elastic.User.Name
 
-  @base_url Elastic.base_url() <> "/_security/role/"
+  defp security_root, do: Elastic.base_url() <> "/_security/role/"
 
   @spec upsert(
           name :: binary(),
@@ -22,7 +22,7 @@ defmodule Elastic.Role do
         ) :: ResponseHandler.upsert_result()
   def upsert(name, body) do
     response =
-      HTTP.put(@base_url <> Name.url_encode(name),
+      HTTP.put(security_root() <> Name.url_encode(name),
         body: body
       )
 
@@ -40,7 +40,7 @@ defmodule Elastic.Role do
 
   @spec delete(name :: binary()) :: ResponseHandler.find_result()
   def delete(name) do
-    HTTP.delete(@base_url <> Name.url_encode(name))
+    HTTP.delete(security_root() <> Name.url_encode(name))
     |> ResponseHandler.process_find_response()
   end
 
@@ -52,7 +52,7 @@ defmodule Elastic.Role do
         _ -> Name.url_encode(name)
       end
 
-    response = HTTP.get(@base_url <> url)
+    response = HTTP.get(security_root() <> url)
 
     case response do
       {:ok, 200, roles} ->

--- a/lib/elastic/scroll.ex
+++ b/lib/elastic/scroll.ex
@@ -9,7 +9,7 @@ defmodule Elastic.Scroll do
   alias Elastic.Index
   alias Elastic.ResponseHandler
 
-  @scroll_endpoint Elastic.base_url() <> "/_search/scroll"
+  defp scroll_endpoint, do: Elastic.base_url() <> "/_search/scroll"
 
   @doc ~S"""
     Starts a new scroll using [ElasticSearch's scroll endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-request-scroll.html#search-request-scroll).
@@ -52,7 +52,7 @@ defmodule Elastic.Scroll do
           required(:keepalive) => any()
         }) :: ResponseHandler.result()
   def next(%{scroll_id: scroll_id, keepalive: keepalive}) do
-    HTTP.get(@scroll_endpoint, body: %{scroll_id: scroll_id, scroll: keepalive})
+    HTTP.get(scroll_endpoint(), body: %{scroll_id: scroll_id, scroll: keepalive})
   end
 
   @doc ~S"""
@@ -73,6 +73,6 @@ defmodule Elastic.Scroll do
   """
   @spec clear(String.t() | [String.t(), ...]) :: ResponseHandler.result()
   def clear(scroll_id) do
-    HTTP.delete(@scroll_endpoint, body: %{scroll_id: scroll_id})
+    HTTP.delete(scroll_endpoint(), body: %{scroll_id: scroll_id})
   end
 end

--- a/lib/elastic/user.ex
+++ b/lib/elastic/user.ex
@@ -15,7 +15,7 @@ defmodule Elastic.User do
   alias Elastic.ResponseHandler
   alias Elastic.User.Name
 
-  @base_url Elastic.base_url() <> "/_security/user/"
+  defp security_root, do: Elastic.base_url() <> "/_security/user/"
 
   @spec upsert(
           username :: binary(),
@@ -23,7 +23,7 @@ defmodule Elastic.User do
         ) :: ResponseHandler.upsert_result()
   def upsert(username, body \\ %{}) do
     response =
-      HTTP.put(@base_url <> Name.url_encode(username),
+      HTTP.put(security_root() <> Name.url_encode(username),
         body:
           Enum.into(
             body,
@@ -62,7 +62,7 @@ defmodule Elastic.User do
         _ -> Name.url_encode(username) <> "/_password"
       end
 
-    response = HTTP.post(@base_url <> url, body: %{password: new_password})
+    response = HTTP.post(security_root() <> url, body: %{password: new_password})
 
     case response do
       {:ok, 200, %{}} ->
@@ -83,7 +83,7 @@ defmodule Elastic.User do
 
   @spec delete(username :: binary()) :: ResponseHandler.find_result()
   def delete(username) do
-    HTTP.delete(@base_url <> Name.url_encode(username))
+    HTTP.delete(security_root() <> Name.url_encode(username))
     |> ResponseHandler.process_find_response()
   end
 
@@ -95,7 +95,7 @@ defmodule Elastic.User do
         _ -> Name.url_encode(username)
       end
 
-    response = HTTP.get(@base_url <> url)
+    response = HTTP.get(security_root() <> url)
 
     case response do
       {:ok, 200, users} ->


### PR DESCRIPTION
## Changes

A `@base_url` module attribute was defined for the security modules, which would call `Elastic.base_url()` at *compile time* and set the return value as the attribute value, effectively hard-coding a potentially incorrect value.

This change replaces the attributes with simple function calls.
